### PR TITLE
 Implement multipart file upload for multiple ontology files

### DIFF
--- a/OLGA/OLGA-Ws/src/main/java/semanticstore/ontology/library/generator/api/interfaces/GeneratorApi.java
+++ b/OLGA/OLGA-Ws/src/main/java/semanticstore/ontology/library/generator/api/interfaces/GeneratorApi.java
@@ -31,13 +31,14 @@
 package semanticstore.ontology.library.generator.api.interfaces;
 
 import io.swagger.annotations.*;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.multipart.MultipartFile;
+
 import javax.annotation.Generated;
 import javax.servlet.http.HttpServletResponse;
-import javax.validation.Valid;
 
 @Generated(value = "io.swagger.codegen.languages.java.SpringCodegen",
     date = "2018-08-08T17:06:42.836-04:00[America/New_York]")
@@ -49,11 +50,10 @@ public interface GeneratorApi {
       notes = "By passing in the appropriate options, you can generate a library for CSharp, Java or Python of your ontology model",
       response = byte[].class)
   @ApiResponses(value = {
-      @ApiResponse(code = 200, message = "OLGA Generated Llibrary Successfully",
+      @ApiResponse(code = 200, message = "OLGA Generated Library Successfully",
           response = byte[].class),
       @ApiResponse(code = 400, message = "invalid input, object invalid")})
-  @RequestMapping(method = RequestMethod.POST, produces = "application/zip",
-      consumes = { "application/xml","application/rdf+xml","application/x-turtle","text/turtle" })
+  @RequestMapping(method = RequestMethod.POST, produces = "application/zip", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public byte[] generate(@RequestParam(value = "code", required = true) String code,
       @RequestParam(value = "name", required = true) String name,
       @RequestParam(value = "library", required = true) String library,
@@ -62,6 +62,6 @@ public interface GeneratorApi {
       @RequestParam(value = "partial", required = false, defaultValue = "false") String partial,
       @RequestParam(value = "skipCompile", required = false,
           defaultValue = "false") boolean skipCompile,
-      @ApiParam(value = "OLGA input parameters") @Valid @RequestBody String body,
+      @RequestParam(value = "file", required = true) MultipartFile file,
       HttpServletResponse response) throws Exception;
 }

--- a/OLGA/OLGA-Ws/src/test/java/org/OLGA/Ws/Generator/Options/SkipCompileOptionTest.java
+++ b/OLGA/OLGA-Ws/src/test/java/org/OLGA/Ws/Generator/Options/SkipCompileOptionTest.java
@@ -24,20 +24,18 @@
  */
 package org.OLGA.Ws.Generator.Options;
 
-import static org.mockito.Mockito.*;
+import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.List;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,7 +52,9 @@ import semanticstore.ontology.library.generator.global.CODE;
 import semanticstore.ontology.library.generator.global.LIBRARY;
 import semanticstore.ontology.library.generator.service.OlgaService;
 import semanticstore.ontology.library.generator.utils.Utils;
+
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
@@ -91,7 +91,7 @@ public class SkipCompileOptionTest {
           .param("library", "trinity").contentType("application/xml")
           .content(new String(
               Files.readAllBytes(Paths.get(this.getClass().getResource("/simple.owl").toURI())),
-              "utf-8"));
+                  StandardCharsets.UTF_8));
     } catch (IOException | URISyntaxException e) {
       e.printStackTrace();
     }
@@ -109,19 +109,19 @@ public class SkipCompileOptionTest {
 
     ArgumentCaptor<Map<String, Object>> input =
         ArgumentCaptor.forClass((Class<Map<String, Object>>) (Class<?>) Map.class);
-    ArgumentCaptor<List<InputStream>> listOfFiles =
-        ArgumentCaptor.forClass((Class<List<InputStream>>) (Class<?>) List.class);
+    ArgumentCaptor<File> file =
+            ArgumentCaptor.forClass((Class<File>) File.class);
     mockMvc.perform(request.param("skipCompile", "true")).andExpect(status().isOk());
 
-    verify(service).invokeOlga(input.capture(), listOfFiles.capture());
+    verify(service).invokeOlga(input.capture(), file.capture());
 
     assertTrue(input.getValue() != null);
     Map<String, Object> inputParm = input.getValue();
     assertTrue(
-        inputParm.containsKey("code") && ((CODE) inputParm.get("code")).equals(CODE.C_SHARP));
+        inputParm.containsKey("code") && inputParm.get("code").equals(CODE.C_SHARP));
     assertTrue(inputParm.containsKey("library")
-        && ((LIBRARY) inputParm.get("library")).equals(LIBRARY.TRINITY));
-    assertTrue(inputParm.containsKey("name") && ((String) inputParm.get("name")).equals("test"));
+        && inputParm.get("library").equals(LIBRARY.TRINITY));
+    assertTrue(inputParm.containsKey("name") && inputParm.get("name").equals("test"));
     assertTrue(inputParm.containsKey("skipCompile") && (boolean) inputParm.get("skipCompile"));
 
   }
@@ -132,19 +132,19 @@ public class SkipCompileOptionTest {
 
     ArgumentCaptor<Map<String, Object>> input =
         ArgumentCaptor.forClass((Class<Map<String, Object>>) (Class<?>) Map.class);
-    ArgumentCaptor<List<InputStream>> listOfFiles =
-        ArgumentCaptor.forClass((Class<List<InputStream>>) (Class<?>) List.class);
+    ArgumentCaptor<File> file =
+            ArgumentCaptor.forClass((Class<File>) File.class);
     mockMvc.perform(request.param("skipCompile", "false")).andExpect(status().isOk());
 
-    verify(service).invokeOlga(input.capture(), listOfFiles.capture());
+    verify(service).invokeOlga(input.capture(), file.capture());
 
     assertTrue(input.getValue() != null);
     Map<String, Object> inputParm = input.getValue();
     assertTrue(
-        inputParm.containsKey("code") && ((CODE) inputParm.get("code")).equals(CODE.C_SHARP));
+        inputParm.containsKey("code") && inputParm.get("code").equals(CODE.C_SHARP));
     assertTrue(inputParm.containsKey("library")
-        && ((LIBRARY) inputParm.get("library")).equals(LIBRARY.TRINITY));
-    assertTrue(inputParm.containsKey("name") && ((String) inputParm.get("name")).equals("test"));
+        && inputParm.get("library").equals(LIBRARY.TRINITY));
+    assertTrue(inputParm.containsKey("name") && inputParm.get("name").equals("test"));
     assertTrue(inputParm.containsKey("skipCompile") && !(boolean) inputParm.get("skipCompile"));
 
   }
@@ -155,19 +155,19 @@ public class SkipCompileOptionTest {
 
     ArgumentCaptor<Map<String, Object>> input =
         ArgumentCaptor.forClass((Class<Map<String, Object>>) (Class<?>) Map.class);
-    ArgumentCaptor<List<InputStream>> listOfFiles =
-        ArgumentCaptor.forClass((Class<List<InputStream>>) (Class<?>) List.class);
+    ArgumentCaptor<File> file =
+            ArgumentCaptor.forClass((Class<File>) File.class);
     mockMvc.perform(request).andExpect(status().isOk());
 
-    verify(service).invokeOlga(input.capture(), listOfFiles.capture());
+    verify(service).invokeOlga(input.capture(), file.capture());
 
     assertTrue(input.getValue() != null);
     Map<String, Object> inputParm = input.getValue();
     assertTrue(
-        inputParm.containsKey("code") && ((CODE) inputParm.get("code")).equals(CODE.C_SHARP));
+        inputParm.containsKey("code") && inputParm.get("code").equals(CODE.C_SHARP));
     assertTrue(inputParm.containsKey("library")
-        && ((LIBRARY) inputParm.get("library")).equals(LIBRARY.TRINITY));
-    assertTrue(inputParm.containsKey("name") && ((String) inputParm.get("name")).equals("test"));
+        && inputParm.get("library").equals(LIBRARY.TRINITY));
+    assertTrue(inputParm.containsKey("name") && inputParm.get("name").equals("test"));
     assertTrue(inputParm.containsKey("skipCompile") && !(boolean) inputParm.get("skipCompile"));
 
   }


### PR DESCRIPTION
Change the generate endpoint to accept multipart form data. The method no longer accepts a request body, but instead a new request parameter named `file` which accepts a zip file that contains the ontology files.

This PR fixes issue https://github.com/EcoStruxure/OLGA/issues/8